### PR TITLE
Vars in boomr being checked against boomr itself

### DIFF
--- a/boomerang.js
+++ b/boomerang.js
@@ -460,7 +460,8 @@ else if(typeof console !== "undefined" && typeof console.log !== "undefined") {
 
 
 for(k in boomr) {
-	if(boomr.hasOwnProperty(k)) {
+	// Copy only if BOOMR doesn't have it.
+	if(!BOOMR.hasOwnProperty(k)) {
 		BOOMR[k] = boomr[k];
 	}
 }


### PR DESCRIPTION
Fixed this. Vars in boomr are checked against BOOMR and copied if BOOMR doesn't have them.
