### PR TITLE
Support for t_page and t_rest with an extension of start_timer

### DIFF
--- a/boomerang.js
+++ b/boomerang.js
@@ -543,9 +543,12 @@ BOOMR.plugins.RT = {
 		return this;
 	},
 
-	startTimer: function(timer_name) {
+	startTimer: function(timer_name, time_value) {
 		if(timer_name) {
-			impl.timers[timer_name] = { start: new Date().getTime() };
+      if  (timer_name == 't_page') {
+        this.endTimer('t_resp', time_value);
+      }
+			impl.timers[timer_name] = {start: (typeof time_value === "number" ? time_value : new Date().getTime())};
 			impl.complete = false;
 		}
 
@@ -588,6 +591,11 @@ BOOMR.plugins.RT = {
 		// If the dev has already called endTimer, then this call will do nothing
 		// else, it will stop the page load timer
 		this.endTimer("t_done");
+
+    // If the dev has already started t_page timer, we can end it now as well
+    if(impl.timers.hasOwnProperty('t_page')) {
+  		this.endTimer("t_page");
+    }
 
 		// A beacon may be fired automatically on page load or if the page dev fires
 		// it manually with their own timers.  It may not always contain a referrer

--- a/boomerang.js
+++ b/boomerang.js
@@ -545,9 +545,9 @@ BOOMR.plugins.RT = {
 
 	startTimer: function(timer_name, time_value) {
 		if(timer_name) {
-      if  (timer_name == 't_page') {
-        this.endTimer('t_resp', time_value);
-      }
+			if (timer_name == 't_page') {
+				this.endTimer('t_resp', time_value);
+			}
 			impl.timers[timer_name] = {start: (typeof time_value === "number" ? time_value : new Date().getTime())};
 			impl.complete = false;
 		}
@@ -592,10 +592,10 @@ BOOMR.plugins.RT = {
 		// else, it will stop the page load timer
 		this.endTimer("t_done");
 
-    // If the dev has already started t_page timer, we can end it now as well
-    if(impl.timers.hasOwnProperty('t_page')) {
-  		this.endTimer("t_page");
-    }
+		// If the dev has already started t_page timer, we can end it now as well
+		if(impl.timers.hasOwnProperty('t_page')) {
+			this.endTimer("t_page");
+		}
 
 		// A beacon may be fired automatically on page load or if the page dev fires
 		// it manually with their own timers.  It may not always contain a referrer


### PR DESCRIPTION
I have worked on a tiny addition for filling in t_page and t_resp. Basically I know what we need is a timestamp of the first byte received before anything is loaded, and that should be outside boomerang namespace. I checked http://developer.yahoo.net/forum/?showtopic=6340&st=0&cookiecheckonly=1 and you mentioned about a global, but I thought this approach might be simple enough.

It's basically extending startTimer to accept a time value and adding a special handling for when the start timer is t_page. 

So you basically capture firstbyte in the beginning of your HTML by doing: 

```
var firstbyte=new Date().getTime();
```

And then in bottom or after the boomerang.js has been loaded, you can do:

```
BOOMR.plugins.RT.startTimer("t_page", firstbyte);
```

and that should do it.
