### PR TITLE
Fix issue #18: beacon not sent when using https

### DIFF
--- a/boomerang.js
+++ b/boomerang.js
@@ -1237,6 +1237,7 @@ BOOMR.plugins.BW = {
 
 			BOOMR.info("HTTPS detected, skipping bandwidth test", "bw");
 			impl.complete = true;
+			BOOMR.sendBeacon();
 			return this;
 		}
 


### PR DESCRIPTION
When the page_ready event fires, all event subscribers are called in
order. By default, the order is:
- BOOMR.plugins.RT.done
- BOOMR.plugins.BW.run

each is supposed to call BOOMR.sendBeacon() when done.

The bug in the https flow is that the BW plugin never calls
BOOMR.sendBeacon() in that block.
