### PR TITLE
Manage built files better

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ boomerang-$(VERSION).$(DATE).js: boomerang.js $(PLUGINS)
 	echo
 	echo "Making $@ ..."
 	echo "using plugins: $(PLUGINS)..."
-	cat boomerang.js $(PLUGINS) | $(MINIFIER) > $@ && echo "done"
+	cat boomerang.js $(PLUGINS) | sed -e 's/^\(BOOMR\.version = "\)$(VERSION)\("\)/\1$(VERSION).$(DATE)\2/' | $(MINIFIER) > $@ && echo "done"
 	echo
 
 .PHONY: all

--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ boomerang-$(VERSION).$(DATE).js: boomerang.js $(PLUGINS)
 	echo
 	echo "Making $@ ..."
 	echo "using plugins: $(PLUGINS)..."
-	cat boomerang.js $(PLUGINS) | sed -e 's/^\(BOOMR\.version = "\)$(VERSION)\("\)/\1$(VERSION).$(DATE)\2/' | $(MINIFIER) > $@ && echo "done"
+	cat boomerang.js $(PLUGINS) | sed -e 's/^\(BOOMR\.version = "\)$(VERSION)\("\)/\1$(VERSION).$(DATE)\2/' | $(MINIFIER) | perl -pe "s/\(window\)\);/\(window\)\);\n/g" > $@ && echo "done"
 	echo
 
 .PHONY: all


### PR DESCRIPTION
This patch improves the built files somewhat:
- BOOMR.version now contains the build number as well so beaconing systems know which build was used
- The built file now has each plugin on a separate line.  This is useful if you have to include different copyright notices for different plugins.
