### PR TITLE
navtiming fallbacks for firefox bug 691547

### DIFF
--- a/boomerang.js
+++ b/boomerang.js
@@ -538,6 +538,11 @@ var impl = {
 			BOOMR.addVar("rt.start", "navigation");
 			this.navigationStart = ti.navigationStart || undefined;
 			this.responseStart = ti.responseStart || undefined;
+
+			// bug in Firefox 7 & 8 https://bugzilla.mozilla.org/show_bug.cgi?id=691547
+			if(navigator.userAgent.match(/Firefox\/[78]\./)) {
+				this.navigationStart = ti.unloadEventStart || ti.fetchStart || undefined;
+			}
 		}
 		else {
 			BOOMR.warn("This browser doesn't support the WebTiming API", "rt");


### PR DESCRIPTION
fallback to using unloadEventStart or fetchStart in firefox 7 and 8 to counter bug 691547.
