### PR TITLE
fix mixed-quote string in BOOMR.init() that would lead to a syntax error...

### DIFF
--- a/doc/howtos/howto-1a-page#1.html
+++ b/doc/howtos/howto-1a-page#1.html
@@ -53,7 +53,7 @@ BOOMR.init({
 		user_ip: "&lt;user's ip address&gt;",
 		beacon_url: "http://yoursite.com/path/to/beacon.php",
 		BW: {
-			base_url: 'http://yoursite.com/path/to/bandwidth/images/"
+			base_url: "http://yoursite.com/path/to/bandwidth/images/"
 		}
 	});
 </pre>


### PR DESCRIPTION
... in Javascript if copy/pasted.
