### PR TITLE
Fixes a bug attaching beacon URL parameters

### DIFF
--- a/boomerang.js
+++ b/boomerang.js
@@ -381,7 +381,7 @@ boomr = {
  
 
 		// use document.URL instead of location.href because of a safari bug
-		url = impl.beacon_url + '?v=' + encodeURIComponent(BOOMR.version) +
+		url = impl.beacon_url + paramPrefix + 'v=' + encodeURIComponent(BOOMR.version) +
 			'&u=' + encodeURIComponent(d.URL.replace(/#.*/, ''));
 
 		for(k in impl.vars) {

--- a/boomerang.js
+++ b/boomerang.js
@@ -373,6 +373,13 @@ boomr = {
 			return this;
 		}
 
+		// if there are already url parameters in the beacon url,
+		// change the first parameter prefix for the boomerang url parameters to &
+                var paramPrefix = '?';
+                if(impl.beacon_url.indexOf('?') > -1)
+                        paramPrefix = '&';
+ 
+
 		// use document.URL instead of location.href because of a safari bug
 		url = impl.beacon_url + '?v=' + encodeURIComponent(BOOMR.version) +
 			'&u=' + encodeURIComponent(d.URL.replace(/#.*/, ''));

--- a/boomerang.js
+++ b/boomerang.js
@@ -375,9 +375,9 @@ boomr = {
 
 		// if there are already url parameters in the beacon url,
 		// change the first parameter prefix for the boomerang url parameters to &
-                var paramPrefix = '?';
-                if(impl.beacon_url.indexOf('?') > -1)
-                        paramPrefix = '&';
+		var paramPrefix = '?';
+		if(impl.beacon_url.indexOf('?') > -1)
+			paramPrefix = '&';
  
 
 		// use document.URL instead of location.href because of a safari bug


### PR DESCRIPTION
When attaching beacon URL parameters boomerang always starts attaching the parameters with "?". This is incorrect if the beacon URL already contains URL parameters. This fix checks whether the URL contains a "?" and if it does, it will attach the parameters prefixed with "&".
